### PR TITLE
Brand customization and forced filtering

### DIFF
--- a/chromium/_locales/en/messages.json
+++ b/chromium/_locales/en/messages.json
@@ -1,6 +1,6 @@
 {
   "extName": {
-    "message": "uBlock Origin Lite",
+    "message": "BYTC Protect",
     "description": "extension name."
   },
   "extShortDesc": {
@@ -196,7 +196,7 @@
     "description": "Name of blocking mode 2"
   },
   "filteringMode3Name": {
-    "message": "complete",
+    "message": "complete filtering enforced",
     "description": "Name of blocking mode 3"
   },
   "basicFilteringModeDescription": {

--- a/chromium/_locales/en_GB/messages.json
+++ b/chromium/_locales/en_GB/messages.json
@@ -1,6 +1,6 @@
 {
   "extName": {
-    "message": "uBlock Origin Lite",
+    "message": "BYTC Protect",
     "description": "extension name."
   },
   "extShortDesc": {
@@ -196,7 +196,7 @@
     "description": "Name of blocking mode 2"
   },
   "filteringMode3Name": {
-    "message": "complete",
+    "message": "complete filtering enforced",
     "description": "Name of blocking mode 3"
   },
   "basicFilteringModeDescription": {

--- a/chromium/manifest.json
+++ b/chromium/manifest.json
@@ -307,7 +307,7 @@
     "scripting",
     "storage"
   ],
-  "short_name": "uBO Lite",
+  "short_name": "BYTC Protect",
   "storage": {
     "managed_schema": "managed_storage.json"
   },

--- a/firefox/_locales/en/messages.json
+++ b/firefox/_locales/en/messages.json
@@ -1,6 +1,6 @@
 {
   "extName": {
-    "message": "uBlock Origin Lite",
+    "message": "BYTC Protect",
     "description": "extension name."
   },
   "extShortDesc": {
@@ -128,7 +128,7 @@
     "description": "Name of blocking mode 2"
   },
   "filteringMode3Name": {
-    "message": "complete",
+    "message": "complete filtering enforced",
     "description": "Name of blocking mode 3"
   },
   "basicFilteringModeDescription": {

--- a/firefox/_locales/en_GB/messages.json
+++ b/firefox/_locales/en_GB/messages.json
@@ -1,6 +1,6 @@
 {
   "extName": {
-    "message": "uBlock Origin Lite",
+    "message": "BYTC Protect",
     "description": "extension name."
   },
   "extShortDesc": {
@@ -128,7 +128,7 @@
     "description": "Name of blocking mode 2"
   },
   "filteringMode3Name": {
-    "message": "complete",
+    "message": "complete filtering enforced",
     "description": "Name of blocking mode 3"
   },
   "basicFilteringModeDescription": {

--- a/firefox/css/popup.css
+++ b/firefox/css/popup.css
@@ -90,6 +90,7 @@ hr {
     align-self: center;
     margin: var(--popup-gap);
     width: calc(var(--popup-main-min-width) - 1em);
+    display: none;
     }
 
 .rulesetTools {

--- a/firefox/dashboard.html
+++ b/firefox/dashboard.html
@@ -38,62 +38,8 @@
         </div>
 
         <div>
-            <h3 data-i18n="defaultFilteringModeSectionLabel"></h3>
-            <p data-i18n="defaultFilteringModeDescription"></p>
-            <div id="defaultFilteringMode">
-                <label class="filteringModeCard">
-                    <div>
-                        <span><span class="input radio"><input type="radio" name="filteringMode" value="1"><svg viewBox="0 0 24 24"><path d="M 12 0 A 12 12 0 0 0 0 12 A 12 12 0 0 0 12 24 A 12 12 0 0 0 24 12 A 12 12 0 0 0 12 0 z M 12 2.5 A 9.5 9.5 0 0 1 21.5 12 A 9.5 9.5 0 0 1 12 21.5 A 9.5 9.5 0 0 1 2.5 12 A 9.5 9.5 0 0 1 12 2.5 z"/><circle cx="12" cy="12" r="7"/></svg></span><span data-i18n="filteringMode1Name">_</span></span>
-                    </div>
-                    <div>
-                        <div class="filteringModeSlider" data-level="1">
-                            <div class="filteringModeButton"><div></div></div>
-                            <span data-level="0"></span>
-                            <span data-level="1"></span>
-                            <span data-level="2"></span>
-                            <span data-level="3"></span>
-                        </div>
-                    </div>
-                    <div data-i18n="basicFilteringModeDescription"></div>
-                </label>
-                <label class="filteringModeCard">
-                    <div>
-                        <span><span class="input radio"><input type="radio" name="filteringMode" value="2"><svg viewBox="0 0 24 24"><path d="M 12 0 A 12 12 0 0 0 0 12 A 12 12 0 0 0 12 24 A 12 12 0 0 0 24 12 A 12 12 0 0 0 12 0 z M 12 2.5 A 9.5 9.5 0 0 1 21.5 12 A 9.5 9.5 0 0 1 12 21.5 A 9.5 9.5 0 0 1 2.5 12 A 9.5 9.5 0 0 1 12 2.5 z"/><circle cx="12" cy="12" r="7"/></svg></span><span data-i18n="filteringMode2Name">_</span></span>
-                    </div>
-                    <div>
-                        <div class="filteringModeSlider" data-level="2">
-                            <div class="filteringModeButton"><div></div></div>
-                            <span data-level="0"></span>
-                            <span data-level="1"></span>
-                            <span data-level="2"></span>
-                            <span data-level="3"></span>
-                        </div>
-                    </div>
-                    <div data-i18n="optimalFilteringModeDescription"></div>
-                </label>
-                <label class="filteringModeCard">
-                    <div>
-                        <span><span class="input radio"><input type="radio" name="filteringMode" value="3"><svg viewBox="0 0 24 24"><path d="M 12 0 A 12 12 0 0 0 0 12 A 12 12 0 0 0 12 24 A 12 12 0 0 0 24 12 A 12 12 0 0 0 12 0 z M 12 2.5 A 9.5 9.5 0 0 1 21.5 12 A 9.5 9.5 0 0 1 12 21.5 A 9.5 9.5 0 0 1 2.5 12 A 9.5 9.5 0 0 1 12 2.5 z"/><circle cx="12" cy="12" r="7"/></svg></span><span data-i18n="filteringMode3Name">_</span></span>
-                    </div>
-                    <div>
-                        <div class="filteringModeSlider" data-level="3">
-                            <div class="filteringModeButton"><div></div></div>
-                            <span data-level="0"></span>
-                            <span data-level="1"></span>
-                            <span data-level="2"></span>
-                            <span data-level="3"></span>
-                        </div>
-                    </div>
-                    <div data-i18n="completeFilteringModeDescription"></div>
-                </label>
-            </div>
-        </div>
-
-        <div>
-            <h3 data-i18n="filteringMode0Name"></h3>
-            <p data-i18n="noFilteringModeDescription">_</p>
-            <p><textarea id="trustedSites" spellcheck="false" placeholder="noFilteringModePlaceholder"></textarea>
-            </p>
+            <h3>Filtering mode</h3>
+            <p>Complete filtering enforced.</p>
         </div>
 
         <div>

--- a/firefox/js/mode-manager.js
+++ b/firefox/js/mode-manager.js
@@ -233,30 +233,12 @@ async function readFilteringModeDetails() {
         readFilteringModeDetails.cache = unserializeModeDetails(sessionModes);
         return readFilteringModeDetails.cache;
     }
-    let [ userModes, adminNoFiltering ] = await Promise.all([
-        localRead('filteringModeDetails'),
-        localRead('adminNoFiltering'),
-    ]);
-    if ( userModes === undefined ) {
-        userModes = { basic: [ 'all-urls' ] };
-    }
-    userModes = unserializeModeDetails(userModes);
-    if ( Array.isArray(adminNoFiltering) ) {
-        for ( const hn of adminNoFiltering ) {
-            applyFilteringMode(userModes, hn, 0);
-        }
-    }
-    filteringModesToDNR(userModes);
-    sessionWrite('filteringModeDetails', serializeModeDetails(userModes));
-    readFilteringModeDetails.cache = userModes;
-    adminRead('noFiltering').then(results => {
-        if ( results ) {
-            localWrite('adminNoFiltering', results);
-        } else {
-            localRemove('adminNoFiltering');
-        }
-    });
-    return userModes;
+    const userModes = { complete: [ 'all-urls' ] };
+    const details = unserializeModeDetails(userModes);
+    filteringModesToDNR(details);
+    sessionWrite('filteringModeDetails', serializeModeDetails(details));
+    readFilteringModeDetails.cache = details;
+    return details;
 }
 
 /******************************************************************************/
@@ -386,6 +368,7 @@ export async function getFilteringMode(hostname) {
 }
 
 export async function setFilteringMode(hostname, afterLevel) {
+    afterLevel = MODE_COMPLETE;
     const filteringModes = await getFilteringModeDetails();
     const level = applyFilteringMode(filteringModes, hostname, afterLevel);
     await writeFilteringModeDetails(filteringModes);
@@ -399,7 +382,7 @@ export function getDefaultFilteringMode() {
 }
 
 export function setDefaultFilteringMode(afterLevel) {
-    return setFilteringMode('all-urls', afterLevel);
+    return setFilteringMode('all-urls', MODE_COMPLETE);
 }
 
 /******************************************************************************/

--- a/firefox/manifest.json
+++ b/firefox/manifest.json
@@ -265,7 +265,7 @@
     "scripting",
     "storage"
   ],
-  "short_name": "uBO Lite",
+  "short_name": "BYTC Protect",
   "version": "2024.9.22.986",
   "web_accessible_resources": [
     {


### PR DESCRIPTION
## Summary
- rename extension to BYTC Protect
- enforce Complete filtering mode
- remove dashboard controls for filtering levels
- hide filtering slider in popup

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_685529ee6e488326a7e60c56ad9cee8b